### PR TITLE
Don't fail if there are warnings

### DIFF
--- a/lib/mix/tasks/nerves/system.lint.ex
+++ b/lib/mix/tasks/nerves/system.lint.ex
@@ -37,6 +37,7 @@ defmodule Mix.Tasks.Nerves.System.Lint do
         |> Defconfig.add_rules(find_rules(rules_dir))
         |> Linter.eval_rules()
         |> print()
+        |> quit()
     end
   end
 
@@ -52,6 +53,7 @@ defmodule Mix.Tasks.Nerves.System.Lint do
         |> Defconfig.add_rules(@default_rules)
         |> Linter.eval_rules()
         |> print()
+        |> quit()
     end
   end
 
@@ -74,14 +76,16 @@ defmodule Mix.Tasks.Nerves.System.Lint do
     case res do
       %Defconfig{errors: [], warnings: [], success: success} = _res ->
         Mix.shell().info([:green, "Successful checks:", "\n\n", Enum.join(success, "\n")])
-        System.halt(0)
       %Defconfig{errors: errors, warnings: warnings, success: success} ->
         Mix.shell().info([:green, "Successful checks:", "\n\n", Enum.join(success, "\n"), "\n"])
         Mix.shell().info("==========================\n")
         Mix.shell().info([:yellow, "Warn checks:", "\n\n", Enum.join(warnings, "\n"), "\n"])
         Mix.shell().info("==========================\n")
         Mix.shell().info([:red, "Failed checks:", "\n\n", Enum.join(errors, "\n")])
-        System.halt(1)
     end
+    res
   end
+
+  defp quit(_res = %Defconfig{errors: []}), do: System.halt(0)
+  defp quit(_res), do: System.halt(1)
 end


### PR DESCRIPTION
For example, it's ok to not include wpa_supplicant if you don't use
WiFi, so don't fail the build.